### PR TITLE
Handler for `unbabble_options`

### DIFF
--- a/lib/LanguageMetaBox.php
+++ b/lib/LanguageMetaBox.php
@@ -15,6 +15,9 @@ class LanguageMetaBox {
 	 * @since 0.0.0
 	 */
 	public function register() {
+		if ( Options::only_one_language_allowed() ) {
+			return;
+		}
 
 		// Post meta box.
 		\add_action( 'add_meta_boxes', [ $this, 'language_metabox' ] );
@@ -71,7 +74,7 @@ class LanguageMetaBox {
 
 	public function ubb_lang_callback( \WP_Post $post ) {
 		$meta    = \get_post_meta( $post->ID, 'ubb_lang', true );
-		$options = \get_option( 'unbabble_options' );
+		$options = Options::get();
 		if ( empty( $meta ) ) {
 			$meta = $options['default_language'];
 		}
@@ -99,7 +102,7 @@ class LanguageMetaBox {
 	}
 
 	public function new_term_language_metabox() {
-		$options = \get_option( 'unbabble_options' );
+		$options = Options::get();
 
 		printf(
 			'<div class="form-field term-language-wrap">
@@ -115,7 +118,7 @@ class LanguageMetaBox {
 
 	public function edit_term_language_metabox( $term ) {
 		$meta    = \get_term_meta( $term->term_id, 'ubb_lang', true );
-		$options = \get_option( 'unbabble_options' );
+		$options = Options::get();
 		if ( empty( $meta ) ) {
 			$meta = $options['default_language'];
 		}
@@ -143,7 +146,7 @@ class LanguageMetaBox {
 		$new_lang = \sanitize_text_field( $_POST['ubb_lang'] );
 
 		if ( $new_lang === '' ) {
-			$options  = \get_option( 'unbabble_options' );
+			$options  = Options::get();
 			$new_lang = $options['default_language'];
 		}
 
@@ -161,6 +164,7 @@ class LanguageMetaBox {
 					\selected( $lang, $selected, false )
 				);
 			},
+			// TODO: This shouldn't happen. Should always be array.
 			is_array( $options['allowed_languages'] ) ? $options['allowed_languages'] : []
 		);
 

--- a/lib/Options.php
+++ b/lib/Options.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace TwentySixB\WP\Plugin\Unbabble;
+
+/**
+ * Handler for the `unbabble_options` option.
+ *
+ * @since 0.0.0
+ */
+class Options {
+
+	public static function get() : array {
+		$options = \get_option( 'unbabble_options' );
+		if ( $options ) {
+			return $options;
+		}
+
+		$wp_locale = \get_locale();
+		return [
+			'allowed_languages' => [ $wp_locale ],
+			'default_language'  => $wp_locale,
+		];
+	}
+
+	public static function only_one_language_allowed() : bool {
+		return count( self::get()['allowed_languages'] ) === 1;
+	}
+}


### PR DESCRIPTION
Add a Handler Class for option `unbabble_options`.

Also hides language metaboxes for entities when the allowed languages are one.