### PR TITLE
Yoast SEO - Options proxy

### DIFF
--- a/lib/Integrations/YoastSEO.php
+++ b/lib/Integrations/YoastSEO.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace TwentySixB\WP\Plugin\Unbabble\Integrations;
+
+class YoastSEO {
+	public function register() {
+		add_filter( 'ubb_proxy_options', fn ( $options ) => array_merge(
+			$options,
+			[ 'wpseo_titles' ]
+		) );
+	}
+}

--- a/lib/Plugin.php
+++ b/lib/Plugin.php
@@ -7,6 +7,7 @@ use TwentySixB\WP\Plugin\Unbabble\Integrations\YoastDuplicatePost;
 use TwentySixB\WP\Plugin\Unbabble\Integrations;
 use TwentySixB\WP\Plugin\Unbabble\CLI;
 use TwentySixB\WP\Plugin\Unbabble\Integrations\Relevanssi;
+use TwentySixB\WP\Plugin\Unbabble\Integrations\YoastSEO;
 use WP_CLI;
 
 /**
@@ -204,6 +205,7 @@ class Plugin {
 		];
 		$integrations = [
 			Relevanssi::class => 'relevanssi/relevanssi.php',
+			YoastSEO::class => 'wordpress-seo/wp-seo.php',
 		];
 
 		\add_action( 'admin_init', function() use ( $admin_integrations ) {


### PR DESCRIPTION
Yoast meta being proxied:
- `wpseo_titles`