### PR TITLE
Fix hidden languages routing - checking user session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Validating user session directly to show hidden languages (#76).
+
 ## [0.4.0] - 2024-07-03
 
 ### Added

--- a/lib/LangInterface.php
+++ b/lib/LangInterface.php
@@ -38,8 +38,8 @@ class LangInterface {
 			return $allowed_languages;
 		}
 
-		// Don't filter language when the user is a high level user.
-		if ( function_exists( 'wp_get_current_user' ) && \current_user_can( 'manage_options' ) ) {
+		// Don't filter language when the user is logged in.
+		if ( self::user_is_logged_in() ) {
 			return $allowed_languages;
 		}
 
@@ -1254,5 +1254,24 @@ class LangInterface {
 		if ( ! $status ) {
 			// TODO: log.
 		}
+	}
+
+	/**
+	 * Returns whether a user is logged in via the session cookie.
+	 *
+	 * This function is a workaround to check for a user session when the routing language check
+	 * runs too early for WordPress to have the user session already fetched and validated.
+	 *
+	 * @since Unreleased
+	 *
+	 * @return bool
+	 */
+	private static function user_is_logged_in() : bool {
+		require_once ABSPATH . WPINC . '/user.php';
+		require_once ABSPATH . WPINC . '/pluggable.php';
+		if ( ! function_exists( 'wp_validate_logged_in_cookie' ) ) {
+			return false;
+		}
+		return is_int( \wp_validate_logged_in_cookie( false ) );
 	}
 }


### PR DESCRIPTION
Since directory language route match runs very early in the loading process, WordPress hasn't yet loaded and validated the user session. 

To get around this we need to validate the session ourselves, by requiring the files we need for the methods to validate the session.