### PR TITLE
Fix Block Editor rest requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Set lang directory in REST url when in admin to fix Block Editor requests for posts/terms.
+
 ## [0.5.1] - 2024-09-03
 
 ### Changed

--- a/lib/Router/Directory.php
+++ b/lib/Router/Directory.php
@@ -376,6 +376,7 @@ class Directory {
 	/**
 	 * Adds directory to home_url.
 	 *
+	 * @since Unreleased Allow 'rest' schemes if in admin to fix Block Editor.
 	 * @since 0.5.0 Added $scheme argument. Stop if $scheme is 'rest'.
 	 * @since 0.0.1
 	 *
@@ -385,7 +386,9 @@ class Directory {
 	 * @return string
 	 */
 	public function home_url( string $url, string $path, ?string $scheme ) : string {
-		if ( $scheme === 'rest' ) {
+
+		// Allow directory in admin rest urls for correct Block Editor functionality.
+		if ( $scheme === 'rest' && ! is_admin() ) {
 			return $url;
 		}
 


### PR DESCRIPTION
REST requests in block editor were not working correctly for post/terms in non-default languages.