### PR TITLE
Admin URLs with default language context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Always add lang query arg to admin urls in Directory routing mode.
+
 ## [0.5.3] - 2024-09-11
 
 ### Added

--- a/lib/Router/Directory.php
+++ b/lib/Router/Directory.php
@@ -470,6 +470,7 @@ class Directory {
 	/**
 	 * Adds directory to admin url.
 	 *
+	 * @since Unreleased Add lang query arg regardless of the current language.
 	 * @since 0.0.3
 	 *
 	 * @param string $url
@@ -477,10 +478,6 @@ class Directory {
 	 */
 	public function admin_url( string $url ) : string {
 		$curr_lang = LangInterface::get_current_language();
-		if ( $curr_lang === LangInterface::get_default_language() ) {
-			return $url;
-		}
-
 		return add_query_arg( 'lang', $curr_lang, $url );
 	}
 


### PR DESCRIPTION
closes #124

Add language context to the admin urls when the user is in the default language.