### PR TITLE
Remove wpdb::prepare when the query doesn't have placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Correct wrong calls to `wpdb::prepare` without any placeholders.
+
 ## [0.5.6] - 2024-11-11
 
 ### Changed

--- a/lib/LangInterface.php
+++ b/lib/LangInterface.php
@@ -573,11 +573,9 @@ class LangInterface {
 
 		$ids_str    = implode( ',', array_map( fn ( $post ) => $post->ID, $posts ) );
 		$post_langs = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT post_id, locale
-				FROM {$table_name}
-				WHERE post_id IN ({$ids_str})"
-			)
+			"SELECT post_id, locale
+			FROM {$table_name}
+			WHERE post_id IN ({$ids_str})"
 		);
 
 		$lang_list = [];
@@ -988,11 +986,9 @@ class LangInterface {
 		}
 
 		$term_langs = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT term_id, locale
-				FROM {$table_name}
-				WHERE term_id IN ({$ids_str})"
-			)
+			"SELECT term_id, locale
+			FROM {$table_name}
+			WHERE term_id IN ({$ids_str})"
 		);
 
 		$lang_list = [];


### PR DESCRIPTION
We should double check to see if there is no need to escape any of the params.