### PR TITLE
Fix search bug in list of translations to link

### DIFF
--- a/lib/Posts/LinkTranslation.php
+++ b/lib/Posts/LinkTranslation.php
@@ -157,7 +157,7 @@ class LinkTranslation {
 
 		$search_filter = '';
 		if ( ! empty( $search ) ) {
-			$search_filter = $wpdb->prepare( "AND P.post_title LIKE %s", '%' . $wpdb->esc_like( $search ) . '%' );
+			$search_filter = $wpdb->prepare( "WHERE group_info LIKE %s", '%' . $wpdb->esc_like( $search ) . '%' );
 		}
 
 		$instr = [];
@@ -203,11 +203,11 @@ class LinkTranslation {
 							INNER JOIN {$wpdb->posts} as P ON (PT.post_id = P.ID)
 							WHERE post_type = %s AND post_status NOT IN ('revision','auto-draft')
 							AND PT.locale IN ('{$allowed_languages_str}')
-							{$search_filter}
 							{$link_filter}
 						) as A
 						GROUP BY source
 					) AS B
+					{$search_filter}
 				) AS C
 				WHERE {$post_lang} = 0
 				ORDER BY group_info ASC


### PR DESCRIPTION
Fixing a bug where searching for translations to link was returning some translation groups that already had the language of the post.

Instead of searching at the start when the translation groups are still being processed, we search after, searching the group info which is a concatenation of post titles, post IDs and language.

Due to searching in this concatenation, we can now search for a specific ID (with false positives due to using a LIKE), for a specific language, and any of the post titles of a translation group.

Since this still is not perfect due to false positives, we could maybe separate these group info parts into multiple columns and search in all of them. Slower but a more accurate search.