### PR TITLE
YoastSEO - handle translatable post type archive indexables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Adds missing class property declarations (PHP 8.2 support).
+- Support for multilingual YoastSEO post type archive indexables. Allows for different SEO information for each archive of a translatable post type.
+
+### Fixed
+
+- Missing WordPress updated option actions when an option's proxy is saved on non default language.
 
 ## [0.5.12] - 2025-03-31
 

--- a/lib/Admin/OptionsProxy.php
+++ b/lib/Admin/OptionsProxy.php
@@ -60,6 +60,7 @@ class OptionsProxy {
 	 * Also updates the base WordPress option when the language is the default. This is to keep the
 	 * default information in the core WordPress incase Unbabble is deactivated/uninstalled.
 	 *
+	 * @since Unreleased Add missing WordPress updated option actions.
 	 * @since 0.2.0
 	 *
 	 * @param mixed $value
@@ -82,6 +83,18 @@ class OptionsProxy {
 		if ( $curr_lang === LangInterface::get_default_language() ) {
 			return $value;
 		}
+
+		// Do updated option actions.
+
+		/**
+		 * Documentation at wp-includes/option.php.
+		 */
+		do_action( "update_option_{$option}", $old_value, $value, $option );
+
+		/**
+		 * Documentation at wp-includes/option.php.
+		 */
+		do_action( 'updated_option', $option, $old_value, $value );
 
 		// Return old value so the value does not get updated.
 		return $old_value;

--- a/lib/Integrations/YoastSEO.php
+++ b/lib/Integrations/YoastSEO.php
@@ -2,11 +2,106 @@
 
 namespace TwentySixB\WP\Plugin\Unbabble\Integrations;
 
+use TwentySixB\WP\Plugin\Unbabble\LangInterface;
+use Yoast\WP\SEO\Models\Indexable;
+
 class YoastSEO {
 	public function register() {
 		add_filter( 'ubb_proxy_options', fn ( $options ) => array_merge(
 			$options,
 			[ 'wpseo_titles' ]
 		) );
+
+		// Handle multilingual post type archive indexables.
+		add_filter( 'wpseo_should_save_indexable', [ $this, 'post_type_archive_indexable' ], 10, 2 );
+	}
+
+	/**
+	 * Handle post type archive indexables for each language.
+	 *
+	 * This is a workaround for Yoast SEO not handling post type archives correctly when using
+	 * Unbabble.
+	 *
+	 * Yoast SEO creates an indexable for each post type archive, but when creating/updating the
+	 * indexable, it only checks for the object type and the object sub type, not the permalink.
+	 * This leads to a single indexable being created for all archive languages.
+	 *
+	 * @since Unreleased
+	 * @param bool $intend_to_save
+	 * @param Indexable $indexable
+	 * @return bool
+	 */
+	public function post_type_archive_indexable( $intend_to_save, $indexable ) {
+		global $wpdb;
+
+		/**
+		 * We could check if $intend_to_save is false and exit early, but it might be changed
+		 * later in the hook process.
+		 *
+		 * We could move this hook function's priority to the end of the hook process, but then
+		 * the indexable would only be changed at the end of the process, and there might be
+		 * other hooked functions which depend on the indexable and its values.
+		 *
+		 * Due to this, its better to change the indexable if needed, even if it will not be
+		 * saved.
+		 */
+
+		// Ignore if first save.
+		if ( empty( $indexable->id ) ) {
+			return $intend_to_save;
+		}
+
+		// Check if the indexable object_type is a post type archive.
+		if ( empty( $indexable->object_type ) || $indexable->object_type !== 'post-type-archive' ) {
+			return $intend_to_save;
+		}
+
+		// Check if the indexalbe object_sub_type is a translatable post type.
+		if ( empty( $indexable->object_sub_type ) || ! LangInterface::is_post_type_translatable( $indexable->object_sub_type ) ) {
+			return $intend_to_save;
+		}
+
+
+		// Get the id of the indexable from the yoast indexable table.
+		$id = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT id FROM {$wpdb->prefix}yoast_indexable WHERE permalink = %s AND object_type = %s AND object_sub_type = %s LIMIT 1",
+				$indexable->permalink,
+				'post-type-archive',
+				$indexable->object_sub_type
+			)
+		);
+
+		// Indexable already exists.
+		if ( $id ) {
+			// Indexable is correct, do nothing.
+			if ( $indexable->id === (int) $id ) {
+				return $intend_to_save;
+			}
+
+			// Indexable is different, set the new id.
+			$indexable->id = $id;
+		} else {
+			// Indexable does not exist, force Yoast SEO to create a new indexable.
+
+			/**
+			 * In order for the ORM to insert a new indexable, we need to set its `is_new`
+			 * property to true.
+			 *
+			 * In order to do this, we need to call create() on the ORM, which will
+			 * set the `is_new` property to true.
+			 *
+			 * The class_name is needed to create() and it might not be set, so we need to set
+			 * it manually.
+			 */
+			$indexable->orm->set_class_name( Indexable::class );
+			$indexable->orm->create();
+
+			// Set the indexable id to null.
+			$indexable->id = null;
+		}
+
+		// Proceed as normal.
+		return $intend_to_save;
 	}
 }


### PR DESCRIPTION
Fixes issues with Yoast SEO information for each post type archive for translatable post types not being able to be different from each other.

Also fixed a bug where the proxied options were not running the WordPress updated option actions when a proxy was saved and the base option was not saved (in non default languages).

### Added

- Support for multilingual YoastSEO post type archive indexables. Allows for different SEO information for each archive of a translatable post type.

### Fixed

- Missing WordPress updated option actions when an option's proxy is saved on non default language.