### PR TITLE
Translating Meta - Regex and Wildcards

### DIFF
--- a/lib/Integrations/YoastDuplicatePost.php
+++ b/lib/Integrations/YoastDuplicatePost.php
@@ -3,6 +3,9 @@
 namespace TwentySixB\WP\Plugin\Unbabble\Integrations;
 
 use TwentySixB\WP\Plugin\Unbabble\LangInterface;
+use TwentySixB\WP\Plugin\Unbabble\Meta\Translations\Helper;
+use TwentySixB\WP\Plugin\Unbabble\Meta\Translations\RegexTranslationKey;
+use TwentySixB\WP\Plugin\Unbabble\Meta\Translations\TranslationKey;
 use WP_Error;
 use WP_Post;
 use WP_Term;
@@ -200,14 +203,14 @@ class YoastDuplicatePost {
 			$default_meta['_thumbnail_id'] = 'post';
 		}
 
-		// TODO: Handle wildcards/regex.
 		// Similar to `ubb_change_language_post_meta_translate_keys` in lib\LangInterface.php.
 		$meta_to_translate = \apply_filters( 'ubb_yoast_duplicate_post_meta_translate_keys', $default_meta, $post_id, $new_lang );
 
 		$self = $this;
 		\add_filter( 'add_post_metadata',
-			function( $check, $new_post_id, $meta_key, $meta_value, $unique ) use ( $self, $meta_to_translate, $post_id, $new_lang ) {
-				if ( ! isset( $meta_to_translate[ $meta_key ] ) ) {
+			function( $check, $new_post_id, $meta_key, $meta_value ) use ( $self, $meta_to_translate, $post_id, $new_lang ) {
+				$type = Helper::match_translation_key( $meta_key, $meta_to_translate );
+				if ( ! $type && in_array( $type, [ 'post', 'term' ], true ) ) {
 					return $check;
 				}
 
@@ -216,14 +219,14 @@ class YoastDuplicatePost {
 					return $check;
 				}
 
-				return $self->translate_meta_value( $check, $new_post_id, $meta_key, $meta_value, $unique, $meta_to_translate, $post_id, $new_lang );
+				return $self->translate_meta_value( $check, $new_post_id, $meta_key, $meta_value, $type, $post_id, $new_lang );
 			},
 			10,
-			5
+			4
 		);
 	}
 
-	public function translate_meta_value( $check, $new_post_id, $meta_key, $meta_value, $unique, $meta_to_translate, $post_id, $new_lang ) {
+	public function translate_meta_value( $check, $new_post_id, $meta_key, $meta_value, $type, $post_id, $new_lang ) {
 
 		// TODO: Filter docs. Might need more arguments.
 		// Similar to `ubb_change_language_post_meta_translate_value` in lib\LangInterface.php.
@@ -237,11 +240,11 @@ class YoastDuplicatePost {
 			return $return;
 		}
 
-		if ( $meta_to_translate[ $meta_key ] === 'post' ) {
+		if ( $type === 'post' ) {
 			return $this->translate_post_meta( $check, $new_post_id, $meta_key, $meta_value, $new_lang );
 		}
 
-		if ( $meta_to_translate[ $meta_key ] === 'term' ) {
+		if ( $type === 'term' ) {
 			return $this->translate_term_meta( $check, $new_post_id, $meta_key, $meta_value, $new_lang );
 		}
 

--- a/lib/Meta/Translations/Helper.php
+++ b/lib/Meta/Translations/Helper.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace TwentySixB\WP\Plugin\Unbabble\Meta\Translations;
+
+/**
+ * Class to help with translating metas.
+ *
+ * @package TwentySixB\WP\Plugin\Unbabble\Meta\Translations
+ * @since Unreleased
+ */
+class Helper {
+
+	/**
+	 * Check if a meta key matches any of the translation keys.
+	 *
+	 * @param string $meta_key
+	 * @param array  $translation_keys
+	 * @return string|null
+	 *
+	 * @since Unreleased
+	 */
+	public static function match_translation_key( string $meta_key, array $translation_keys ) : ?string {
+
+		// Match simple keys first that are not using TranslationKey's.
+		if (
+			isset( $translation_keys[ $meta_key ] )
+			&& ! $translation_keys[ $meta_key ] instanceof TranslationKey
+			&& is_string( $translation_keys[ $meta_key ] )
+		) {
+			return $translation_keys[ $meta_key ];
+		}
+
+		// Match simple keys that are using TranslationKey's.
+		if (
+			isset( $translation_keys[ $meta_key ] )
+			&& $translation_keys[ $meta_key ] instanceof TranslationKey
+			&& $translation_keys[ $meta_key ]->matches( $meta_key )
+		) {
+			return $translation_keys[ $meta_key ]->get_type();
+		}
+
+		// Match regex keys.
+		foreach ( $translation_keys as $value ) {
+			if ( ! $value instanceof RegexTranslationKey ) {
+				continue;
+			}
+
+			if ( $value->matches( $meta_key ) ) {
+				return $value->get_type();
+			}
+		}
+
+		// None of the keys matched.
+		return null;
+	}
+}

--- a/lib/Meta/Translations/RegexTranslationKey.php
+++ b/lib/Meta/Translations/RegexTranslationKey.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace TwentySixB\WP\Plugin\Unbabble\Meta\Translations;
+
+/**
+ * Class to help with translating metas that have regex rules.
+ *
+ * This class is used to store the regex key, type of a translation. Also allow for a sql like
+ * key to be used for the sql queries.
+ *
+ * @package TwentySixB\WP\Plugin\Unbabble\Meta\Translations
+ * @since Unreleased
+ */
+class RegexTranslationKey extends TranslationKey {
+
+	/**
+	 * A SQL LIKE key similar to the regex key used for sql queries to match the key.
+	 *
+	 * @var string
+	 * @since Unreleased
+	 */
+	protected $sql_like_key;
+
+	/**
+	 * @param string $key
+	 * @param string $type
+	 * @param string $sql_like_key
+	 * @since Unreleased
+	 */
+	public function __construct( string $key, string $type, string $sql_like_key = '' ) {
+		parent::__construct( $key, $type );
+		$this->sql_like_key = $sql_like_key;
+	}
+
+	/**
+	 * Check if the regex key matches the given key.
+	 *
+	 * @param string $key_to_match
+	 * @return bool
+	 */
+	public function matches( string $key_to_match ) : bool {
+		$regex = $this->key;
+		if ( ! str_starts_with( $regex, '/' ) ) {
+			$regex = '/' . $regex;
+		}
+		if ( ! str_ends_with( $regex, '/' ) ) {
+			$regex .= '/';
+		}
+
+		return preg_match( $this->key, $key_to_match ) === 1;
+	}
+
+	/**
+	 * Check if the regex key has a SQL LIKE key.
+	 *
+	 * @return bool
+	 */
+	public function has_sql_like() : bool {
+		return ! empty( $this->sql_like_key );
+	}
+
+	/**
+	 * Get the SQL LIKE key
+	 *
+	 * @return string
+	 */
+	public function get_sql_like() : string {
+		return $this->sql_like_key;
+	}
+}

--- a/lib/Meta/Translations/TranslationKey.php
+++ b/lib/Meta/Translations/TranslationKey.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace TwentySixB\WP\Plugin\Unbabble\Meta\Translations;
+
+/**
+ * Class to help with translating metas.
+ *
+ * This class is used to store the key and type of a translation.
+ *
+ * @package TwentySixB\WP\Plugin\Unbabble\Meta\Translations
+ * @since Unreleased
+ */
+class TranslationKey {
+
+	/**
+	 * @var string
+	 * @since Unreleased
+	 */
+	protected $key;
+
+	/**
+	 * @var string
+	 * @since Unreleased
+	 */
+	protected $type;
+
+	/**
+	 * @param string $key
+	 * @param string $type
+	 * @since Unreleased
+	 */
+	public function __construct( string $key, string $type ) {
+		$this->key  = $key;
+		$this->type = $type;
+	}
+
+	/**
+	 * Get the meta key.
+	 *
+	 * @return string
+	 * @since Unreleased
+	 */
+	public function get_key() : string {
+		return $this->key;
+	}
+
+	/**
+	 * Get the type of the meta key.
+	 *
+	 * @return string
+	 * @since Unreleased
+	 */
+	public function get_type() : string {
+		return $this->type;
+	}
+
+	/**
+	 * Check if the key matches the given key.
+	 *
+	 * @param string $key_to_match
+	 * @return bool
+	 * @since Unreleased
+	 */
+	public function matches( string $key_to_match ) : bool {
+		return $this->key === $key_to_match;
+	}
+}


### PR DESCRIPTION
- [ ] Encapsulate large code blocks
- [ ] Add missing @since
- [ ] Add missing explanations for new code parts
- [ ] Add changes to CHANGELOG

These changes improve on the translation of meta fields on Duplicate Post or Post Language Change. Previously we were not handling meta keys with wildcard's '%' or regex, such as the ones our ACF integration introduced into the "meta keys to translate" arrays.

In order to better handle the data inside PHP arrays, a couple of classes were created to contain information about each meta key and methods to simplify handling them. One class `TranslationKey`is for simple meta keys that don't need regex or wildcards to match, the other is one, `RegexTranslationKey`,for Regex. The `RegexTranslationKey` class can also include a SQL LIKE version of it's key.

These classes help the process of matching in:

- **lib/Integrations/YoastDuplicatePost.php**: to more easily match what keys we're duplicating that need to be translate. It becomes easier to differentiate between what meta keys are just a direct comparison or need a regex match.
- **lib/LangInterface.php**: when changing a post's language, being able to differentiate between direct comparison keys (IN), regex keys (REGEXP), or regex keys with a good enough SQL LIKE equivalent (LIKE), makes it easier to create a database `postmeta` query to fetch all meta key/value pairs that need to be translated